### PR TITLE
Compiles with MinGW and Runs on WINE 5.0.   Plus other fixes. 

### DIFF
--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -99,7 +99,7 @@ man_MANS = man/par3.1
 par3_SOURCES = src/main.c \
 	src/common.h \
 	src/common.c
-par3_LDADD = libpar3.a libblake3.a libleopard.a -lstdc++
+par3_LDADD = libpar3.a libblake3.a libleopard.a -lstdc++ -lm
 
 # -mavx supports AVX instructions
 AM_CFLAGS = -Wall -mavx -mavx2 -mavx512f -mavx512vl -mavx512bw

--- a/linux/MinGW.txt
+++ b/linux/MinGW.txt
@@ -29,13 +29,4 @@ MinGW/WINE
 	Then, you should be able to run "wine par3.exe --help"
 	to test that it works.
 
-	If WINE is working, you can run tests in WINE with
-	the command:
-	make check
-
-	WARNING: If the tests see that par3 or the unit tests have
-	an ".exe" extension, they will be automatically run with
-	WINE.  When switching from MinGW to normal GCC, you need
-	to run "make clean" or the tests may run the wrong version
-	(or run both versions).
 

--- a/linux/configure.ac
+++ b/linux/configure.ac
@@ -29,6 +29,17 @@ AC_CONFIG_SRCDIR([src/main.c])
 
 AC_CANONICAL_HOST
 
+dnl disable SIMD for MinGW
+case "$host" in
+     *-*-mingw*)
+       CFLAGS="$CFLAGS -DBLAKE3_NO_AVX512"
+       CFLAGS="$CFLAGS -DBLAKE3_NO_SSE41"
+       CFLAGS="$CFLAGS -DBLAKE3_NO_SSE2"
+       ;;
+     *)
+       ;;
+esac
+
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE
 
@@ -51,6 +62,7 @@ AC_SUBST([CXXFLAGS])
 
 dnl Set language to C
 AC_LANG(C)
+
 
 dnl Checks for header files.
 AC_HEADER_DIRENT

--- a/linux/src/common.c
+++ b/linux/src/common.c
@@ -13,6 +13,7 @@
 
 /* This definition of _MAX_FNAME works for GCC on POSIX systems */
 #include <limits.h>
+#include <sys/stat.h>
 #define _MAX_FNAME NAME_MAX
 
 #define _strnicmp strncasecmp
@@ -26,6 +27,46 @@
 
 #include "common.h"
 
+
+
+#if __linux__
+
+// Reproduce Windows system call with Linux's fstat 
+int64_t _filelengthi64(int fd) {
+  struct stat buffer;
+  int result;
+
+  result = fstat(fd, &buffer);
+  if (result == 0) {
+    // success
+    return buffer.st_size;
+  }
+  else {
+    // failure
+    return (int64_t) -1;  // this should sign-extend
+  }
+}
+
+
+/* This is based on code from: https://stackoverflow.com/questions/50119172/how-to-get-the-file-length-in-c-on-linux  
+   Why lseek instead of fstat??
+int64_t _filelengthi64(int filedes)
+{
+    off_t pos = lseek(filedes, 0, SEEK_CUR);
+    if (pos != (off_t)-1)
+    {
+        off_t size = lseek(filedes, 0, SEEK_END);
+        lseek(filedes, pos, SEEK_SET);
+        return (int64_t)size;
+    }
+    return (int64_t)-1;
+}
+*/
+
+
+
+#elif _WIN32
+#endif
 
 // return pointer of filename
 char * offset_file_name(char *file_path)

--- a/linux/src/common.h
+++ b/linux/src/common.h
@@ -1,3 +1,19 @@
+#ifndef __COMMON_H__
+#define __COMMON_H__
+
+#if __linux__
+
+#include <linux/limits.h>
+#define _MAX_PATH PATH_MAX
+
+// Windows system call 
+int64_t _filelengthi64(int fd);
+
+#elif _WIN32
+
+#endif
+
+
 
 char * offset_file_name(char *file_path);
 int sanitize_file_name(char *name);
@@ -22,3 +38,4 @@ int popcount32(uint32_t x);
 int roundup_log2(uint64_t x);
 uint64_t next_pow2(uint64_t x);
 
+#endif // __COMMON_H__

--- a/linux/src/file.c
+++ b/linux/src/file.c
@@ -2,6 +2,14 @@
 // avoid error of MSVC
 #define _CRT_SECURE_NO_WARNINGS
 
+/* Redefinition of _FILE_OFFSET_BITS must happen BEFORE including stdio.h */
+#ifdef __linux__
+#define _FILE_OFFSET_BITS 64
+#define _stat64 stat
+#elif _WIN32
+#endif 
+
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stddef.h>
@@ -20,6 +28,8 @@
    we should consider using ctime_r().  */
 #define __time64_t int64_t
 #define _ctime64 ctime
+
+#include <sys/stat.h>
 
 #elif _WIN32
 

--- a/linux/src/libpar3.c
+++ b/linux/src/libpar3.c
@@ -2,6 +2,14 @@
 // avoid error of MSVC
 #define _CRT_SECURE_NO_WARNINGS
 
+/* Redefinition of _FILE_OFFSET_BITS must happen BEFORE including stdio.h */
+#ifdef __linux__
+#define _FILE_OFFSET_BITS 64
+#define _stat64 stat
+#elif _WIN32
+#endif 
+
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -9,35 +17,29 @@
 #include <string.h>
 #include <math.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-
 #if __linux__
 
-#define _stat64 stat
-
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <strings.h>
 #define _strnicmp strncasecmp
 #define _stricmp strcasecmp
 
 #elif _WIN32
+
+// MSVC headers
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <direct.h>
+#include <io.h>
 #endif
 
 #include "libpar3.h"
 #include "common.h"
 
 
-
-
 #if __linux__
-
-// MSVC headers
 #elif _WIN32
-
-// MSVC headers
-#include <direct.h>
-#include <io.h>
-
 
 // recursive search into sub-directories
 static int path_search_recursive(PAR3_CTX *par3_ctx, char *sub_dir)

--- a/linux/src/packet_make.c
+++ b/linux/src/packet_make.c
@@ -2,6 +2,14 @@
 // avoid error of MSVC
 #define _CRT_SECURE_NO_WARNINGS
 
+/* Redefinition of _FILE_OFFSET_BITS must happen BEFORE including stdio.h */
+#ifdef __linux__
+#define _FILE_OFFSET_BITS 64
+#define _stat64 stat
+#elif _WIN32
+#endif 
+
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -9,6 +17,8 @@
 #include <string.h>
 
 #if __linux__
+
+#include <sys/stat.h>
 
 #elif _WIN32
 
@@ -38,12 +48,6 @@ void make_packet_header(uint8_t *buf, uint64_t packet_size, uint8_t *set_id, uin
 		blake3(buf + 24, packet_size - 24, buf + 8);
 }
 
-
-#if __linux__
-
-#warning "static void generate_set_id(PAR3_CTX *par3_ctx, uint8_t *buf, size_t body_size) is UNDEFINED"
-
-#elif _WIN32
 
 // Input is packet body of Start Packet.
 // Return generated InputSetID at "buf - 16".
@@ -177,7 +181,6 @@ static void generate_set_id(PAR3_CTX *par3_ctx, uint8_t *buf, size_t body_size)
 	blake3_hasher_update(&hasher, buf, body_size);
 	blake3_hasher_finalize(&hasher, buf - 16, 8);
 }
-#endif
 
 
 // Start Packet, Creator Packet, Comment Packet

--- a/linux/src/read.c
+++ b/linux/src/read.c
@@ -2,6 +2,14 @@
 // avoid error of MSVC
 #define _CRT_SECURE_NO_WARNINGS
 
+/* Redefinition of _FILE_OFFSET_BITS must happen BEFORE including stdio.h */
+#ifdef __linux__
+#define _FILE_OFFSET_BITS 64
+#define _fileno fileno
+#elif _WIN32
+#endif 
+
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -11,25 +19,7 @@
 
 #if __linux__
 
-/* in stdio.h */
-#define _fileno fileno
-
 #include <sys/stat.h>
-
-int64_t _filelengthi64(int fd) {
-  struct stat buffer;
-  int result;
-
-  result = fstat(fd, &buffer);
-  if (result == 0) {
-    // success
-    return buffer.st_size;
-  }
-  else {
-    // failure
-    return (int64_t) -1;  // this should sign-extend
-  }
-}
 
 #elif _WIN32
 

--- a/linux/src/verify_check.c
+++ b/linux/src/verify_check.c
@@ -18,21 +18,6 @@
 #include <time.h>
 
 #ifdef __linux__
-
-/* Based on code from: https://stackoverflow.com/questions/50119172/how-to-get-the-file-length-in-c-on-linux  */
-int64_t _filelengthi64(int filedes)
-{
-    off_t pos = lseek(filedes, 0, SEEK_CUR);
-    if (pos != (off_t)-1)
-    {
-        off_t size = lseek(filedes, 0, SEEK_END);
-        lseek(filedes, pos, SEEK_SET);
-        return (int64_t)size;
-    }
-    return (int64_t)-1;
-}
-
-
 #elif _WIN32
 // MSVC headers
 #include <io.h>


### PR DESCRIPTION
This version compiles with MinGW and runs on WINE 5.0.  Blake3's support for AVX512 had to be disabled to run on WINE 5.0.  

It fixes some build errors: adds -lm to the link line, linux implementation of _filelengthi64 moved to common.h/c

More code ported from Windows to Linux.  Most uses the _stat64 call.    