### PR TITLE
Bug fix + small changes towards getting Linux to natively compile

### DIFF
--- a/linux/src/block_check.c
+++ b/linux/src/block_check.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <limits.h>
 

--- a/linux/src/block_map.c
+++ b/linux/src/block_map.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <limits.h>
 

--- a/linux/src/block_recover.c
+++ b/linux/src/block_recover.c
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <time.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <unistd.h>
 

--- a/linux/src/common.c
+++ b/linux/src/common.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <wchar.h>
 
-#if __linux__
+#ifdef __linux__
 
 /* This definition of _MAX_FNAME works for GCC on POSIX systems */
 #include <limits.h>
@@ -25,7 +25,7 @@
 
 
 
-#if __linux__
+#ifdef __linux__
 
 // Reproduce Windows system call with Linux's fstat 
 int64_t _filelengthi64(int fd) {
@@ -160,7 +160,7 @@ int sanitize_file_name(char *name)
 }
 
 
-#if __linux__
+#ifdef __linux__
 #warning "int get_absolute_path(char *absolute_path, char *relative_path, size_t max) is UNDEFINED"
 #elif _WIN32
 // convert relative path to absolute path

--- a/linux/src/common.c
+++ b/linux/src/common.c
@@ -161,7 +161,22 @@ int sanitize_file_name(char *name)
 
 
 #ifdef __linux__
-#warning "int get_absolute_path(char *absolute_path, char *relative_path, size_t max) is UNDEFINED"
+
+int get_absolute_path(char *absolute_path, char *relative_path, size_t max) {
+  // Linux is case-sensative, so it doesn't have to be lower/upper-cased.
+
+  // allocate buffer, in case max is less than PATH_MAX
+  char buf[PATH_MAX+1];
+  
+  if (realpath(relative_path, buf) != NULL) {
+    strncpy(absolute_path, buf, max);
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+
 #elif _WIN32
 // convert relative path to absolute path
 int get_absolute_path(char *absolute_path, char *relative_path, size_t max)

--- a/linux/src/file.c
+++ b/linux/src/file.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <time.h>
 
-#if __linux__
+#ifdef __linux__
 
 #warning "Assuming this Linux system uses 64-bit time."
 /* There doesn't seem to be a preprocessor test for 64-bit time_t! 
@@ -62,7 +62,7 @@ static uint64_t FileTimeToTimet(uint64_t file_time)
 }
 
 
-#if __linux__
+#ifdef __linux__
 #elif _WIN32
 
 // File System Specific Packets (optional packets)
@@ -304,7 +304,7 @@ void read_file_system_option(PAR3_CTX *par3_ctx, int packet_type, int64_t offset
 }
 
 
-#if __linux__
+#ifdef __linux__
 
 #warning "static int check_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, void *stat_p) is UNDEFINED"
 
@@ -443,7 +443,7 @@ int check_file_system_option(PAR3_CTX *par3_ctx, int packet_type, int64_t offset
 }
 
 
-#if __linux__
+#ifdef __linux__
 
 #warning "static int reset_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, char *file_name); is UNDEFINED"
 

--- a/linux/src/file.c
+++ b/linux/src/file.c
@@ -26,6 +26,9 @@
 
 #include <sys/stat.h>
 
+// permission to write by owner
+#define _S_IWRITE S_IWUSR
+
 #elif _WIN32
 
 // MSVC headers
@@ -61,9 +64,6 @@ static uint64_t FileTimeToTimet(uint64_t file_time)
 	return unix_time;
 }
 
-
-#ifdef __linux__
-#elif _WIN32
 
 // File System Specific Packets (optional packets)
 /*
@@ -142,6 +142,8 @@ int make_unix_permission_packet(PAR3_CTX *par3_ctx, char *file_name, uint8_t *ch
 	return 0;
 }
 
+
+
 // FAT Permissions Packet
 // 0 = write ok, 1 = failed (no checksum)
 // Return checksum of FAT Permissions Packet in *checksum.
@@ -188,7 +190,7 @@ int make_fat_permission_packet(PAR3_CTX *par3_ctx, char *file_name, uint8_t *che
 
 	return 0;
 }
-#endif
+
 
 // For showing file list
 static void show_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum)
@@ -304,12 +306,6 @@ void read_file_system_option(PAR3_CTX *par3_ctx, int packet_type, int64_t offset
 }
 
 
-#ifdef __linux__
-
-#warning "static int check_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, void *stat_p) is UNDEFINED"
-
-#elif _WIN32
-
 // For verification
 static int check_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, void *stat_p)
 {
@@ -382,7 +378,6 @@ static int check_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, void *s
 
 	return ret;
 }
-#endif
 
 
 // packet_type: 1 = file, 2 = directory, 3 = root

--- a/linux/src/file.c
+++ b/linux/src/file.c
@@ -24,10 +24,16 @@
 #define __time64_t int64_t
 #define _ctime64 ctime
 
+#define _chmod chmod
+
 #include <sys/stat.h>
+#include <utime.h>
 
 // permission to write by owner
 #define _S_IWRITE S_IWUSR
+
+#define _utime utime
+#define _utimbuf utimbuf
 
 #elif _WIN32
 
@@ -438,11 +444,6 @@ int check_file_system_option(PAR3_CTX *par3_ctx, int packet_type, int64_t offset
 }
 
 
-#ifdef __linux__
-
-#warning "static int reset_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, char *file_name); is UNDEFINED"
-
-#elif _WIN32
 
 // For repair
 static int reset_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, char *file_name)
@@ -541,7 +542,6 @@ static int reset_file_system_info(PAR3_CTX *par3_ctx, uint8_t *checksum, char *f
 
 	return ret;
 }
-#endif
 
 
 // packet_type: 1 = file, 2 = directory, 3 = root

--- a/linux/src/inside_zip.c
+++ b/linux/src/inside_zip.c
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <unistd.h>
 

--- a/linux/src/libpar3.c
+++ b/linux/src/libpar3.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <math.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -35,7 +35,7 @@
 #include "common.h"
 
 
-#if __linux__
+#ifdef __linux__
 #elif _WIN32
 
 // recursive search into sub-directories

--- a/linux/src/main.c
+++ b/linux/src/main.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <unistd.h> 
 #define _chdir  chdir

--- a/linux/src/packet_make.c
+++ b/linux/src/packet_make.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <sys/stat.h>
 

--- a/linux/src/read.c
+++ b/linux/src/read.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __linux__
+#ifdef __linux__
 
 #include <sys/stat.h>
 

--- a/linux/src/repair.c
+++ b/linux/src/repair.c
@@ -27,7 +27,7 @@
 #include <direct.h>
 #include <sys/stat.h>
 
-#define S_ISDIR(m) (((m) & _S_IFDIR) == _S_IFDIR)
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
 
 #endif
 

--- a/linux/src/verify.c
+++ b/linux/src/verify.c
@@ -18,9 +18,9 @@
 #include <sys/stat.h>
 
 // _S_IFDIR = 0x4000
-#define S_ISDIR(m) (((m) & _S_IFDIR) == _S_IFDIR)
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
 // _S_IFREG = 0x8000
-#define S_ISREG(m) (((m) & _S_IFREG) == _S_IFREG)
+#define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
 #endif
 
 #include "blake3/blake3.h"


### PR DESCRIPTION
Found and fixed a bug in how directories are identified.  

Made a few more files in linux/ directory compile natively on Linux.

Still need to change "par_search", "path_search", and "extra_search" in libpar3.c.  They use the _findfirst64() function which is not available on Linux. 
