### PR TITLE
Fix read out of bounds, which sometimes caused recovery failure.

### DIFF
--- a/linux/src/reedsolomon16.c
+++ b/linux/src/reedsolomon16.c
@@ -196,7 +196,7 @@ int rs16_invert_matrix_cauchy(PAR3_CTX *par3_ctx, int lost_count)
 	// Set index of existing input blocks after
 	k = 0;
 	for (j = 0; j < block_count; j++){
-		if (j == lost_id[k]){
+		if (k < lost_count && j == lost_id[k]){
 			k++;
 			continue;
 		}

--- a/linux/src/reedsolomon8.c
+++ b/linux/src/reedsolomon8.c
@@ -157,7 +157,7 @@ int rs8_invert_matrix_cauchy(PAR3_CTX *par3_ctx, int lost_count)
 	// Set index of existing input blocks after
 	k = 0;
 	for (j = 0; j < block_count; j++){
-		if (j == lost_id[k]){
+		if (k < lost_count && j == lost_id[k]){
 			k++;
 			continue;
 		}

--- a/windows/src/reedsolomon16.c
+++ b/windows/src/reedsolomon16.c
@@ -196,7 +196,7 @@ int rs16_invert_matrix_cauchy(PAR3_CTX *par3_ctx, int lost_count)
 	// Set index of existing input blocks after
 	k = 0;
 	for (j = 0; j < block_count; j++){
-		if (j == lost_id[k]){
+		if (k < lost_count && j == lost_id[k]){
 			k++;
 			continue;
 		}

--- a/windows/src/reedsolomon8.c
+++ b/windows/src/reedsolomon8.c
@@ -157,7 +157,7 @@ int rs8_invert_matrix_cauchy(PAR3_CTX *par3_ctx, int lost_count)
 	// Set index of existing input blocks after
 	k = 0;
 	for (j = 0; j < block_count; j++){
-		if (j == lost_id[k]){
+		if (k < lost_count && j == lost_id[k]){
 			k++;
 			continue;
 		}


### PR DESCRIPTION
Previously, when `k == lost_count`, `lost_id[k]` would read out of bounds. If the memory happens to contain a valid block index, then that block would be skipped and the matrix would be calculated incorrectly.

This occasionally caused a repair operation to fail (but not always), which would be detected by the file verification afterwards.

Due to the nondeterministic nature of the bug this was hard to pin down, but Valgrind was helpful in detecting the invalid read.